### PR TITLE
Upgrade Spring Boot, Spring Cloud and dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.1.7.RELEASE</version>
+		<version>3.2.4</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.starkandwayne</groupId>
@@ -14,8 +14,8 @@
 	<name>spring-cloud-config-server</name>
 	<description>Stark &amp; Wayne Spring Cloud Congfig Server based on Greenwich SR3</description>
 	<properties>
-		<java.version>1.8</java.version>
-		<spring-cloud.version>Greenwich.SR3</spring-cloud.version>
+		<java.version>17</java.version>
+		<spring-cloud.version>2023.0.1</spring-cloud.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -25,12 +25,17 @@
 		<dependency>
 		<groupId>org.springframework.credhub</groupId>
 		<artifactId>spring-credhub-starter</artifactId>
-		<version>2.1.1.RELEASE</version>
+		<version>3.1.0</version>
 	    </dependency>
+		<dependency>
+            <groupId>org.springframework.credhub</groupId>
+            <artifactId>spring-credhub-core</artifactId>
+            <version>3.1.0</version>
+        </dependency>
 		<dependency>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-actuator</artifactId>
-		<version>2.3.10.RELEASE</version>
+		<version>3.3.1</version>
 	    </dependency>
 		<dependency>
 		<groupId>org.springframework.security</groupId>

--- a/src/main/java/com/starkandwayne/springcloudconfigserver/dashboard/AssetsConfiguration.java
+++ b/src/main/java/com/starkandwayne/springcloudconfigserver/dashboard/AssetsConfiguration.java
@@ -7,15 +7,16 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
-import org.springframework.security.config.annotation.web.configurers.ExpressionUrlAuthorizationConfigurer;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.servlet.HandlerMapping;
 import org.springframework.web.servlet.handler.SimpleUrlHandlerMapping;
 
 @Order(0)
 @Configuration
+@EnableWebSecurity
 @Profile({"!test", "dashboardTest"})
-public class AssetsConfiguration extends WebSecurityConfigurerAdapter {
+public class AssetsConfiguration {
    private final ApplicationContext applicationContext;
    private String ASSETS_URL_PREFIX = "/assets/**";
 
@@ -36,7 +37,12 @@ public class AssetsConfiguration extends WebSecurityConfigurerAdapter {
       return assetsHandlerMapping;
    }
 
-   protected void configure(HttpSecurity http) throws Exception {
-      ((ExpressionUrlAuthorizationConfigurer<HttpSecurity>.AuthorizedUrl)((HttpSecurity)http.antMatcher(this.ASSETS_URL_PREFIX).headers().cacheControl().disable().and()).authorizeRequests().anyRequest()).permitAll();
+   @Bean
+   public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+       http
+           .securityMatcher (ASSETS_URL_PREFIX)
+           .headers(headers -> headers.cacheControl(cache -> cache.disable()))
+           .authorizeHttpRequests(authorize -> authorize.requestMatchers(ASSETS_URL_PREFIX).permitAll());
+       return http.build();
    }
 }


### PR DESCRIPTION
- Updated Spring Boot version from 2.1.7.RELEASE to 3.2.4
- Updated Java version from 1.8 to 17
- Updated Spring Cloud version from Greenwich.SR3 to 2023.0.1
- Upgraded spring-credhub-starter to 3.1.0 and added spring-credhub-core dependency
- Upgraded spring-boot-starter-actuator to 3.3.1
- Refactored AssetsConfiguration to use SecurityFilterChain instead of
WebSecurityConfigurerAdapter for compatibility
with new Spring Security version